### PR TITLE
Remove leftover struct Signals.

### DIFF
--- a/Quixote/quixote-export.c
+++ b/Quixote/quixote-export.c
@@ -127,20 +127,6 @@ static String Output_String = NULL;
 
 
 /**
- * The following variable holds booleans which describe signals
- * which were received.
- */
-struct {
-	_Bool sigint;
-	_Bool sigterm;
-	_Bool sighup;
-	_Bool sigquit;
-	_Bool stop;
-
-	_Bool sigchild;
-} Signals;
-
-/**
  * The following enumeration type specifies whether or not
  * the measurements are being managed internally or by an SGX enclave.
  */

--- a/Quixote/quixote-us.c
+++ b/Quixote/quixote-us.c
@@ -159,20 +159,6 @@ static _Bool Enforce = false;
 static char *TSEM_model = NULL;
 
 /**
- * The following variable holds booleans which describe signals
- * which were received.
- */
-struct {
-	_Bool sigint;
-	_Bool sigterm;
-	_Bool sighup;
-	_Bool sigquit;
-	_Bool stop;
-
-	_Bool sigchild;
-} Signals;
-
-/**
  * The following enumeration type specifies whether or not
  * the measurements are being managed internally or by an SGX enclave.
  */


### PR DESCRIPTION
The Signals structures are no longer needed in quixote-us and quixote-export since signals are now handled in TSEMworkload object.

The leftover structures also caused "multiple definition" error with gcc.